### PR TITLE
Install Grunt and DocPad as peer dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,16 @@
   "engines": {
     "node": ">= 0.8.0"
   },
-  "dependencies": {
-    "docpad": "~6.63.3"
-  },
   "devDependencies": {
+    "docpad": "~0.63.3",
     "docpad-plugin-eco": "~2.0.2",
     "docpad-plugin-marked": "~2.1.1",
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.6.0"
+  },
+  "peerDependencies": {
+    "grunt": "~0.4.0",
+    "docpad": "^6.64.0"
   },
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
Considering how the plugin acts as a thin wrapper, it made sense to me to install DocPad as a peer dependency.
